### PR TITLE
chore: Prepare-release more packages to update

### DIFF
--- a/build/Makefile.Release
+++ b/build/Makefile.Release
@@ -11,7 +11,7 @@ validate-release-uniqueness:
 
 .PHONY: prepare-release
 prepare-release:
-	@$(SCRIPT_DIR)/prepare-release.sh $(version) ${SELF_REFERENCE_PACKAGES_SOURCE}
+	@$(SCRIPT_DIR)/prepare-release.sh $(version) "${PACKAGES_SOURCE_TO_UPDATE}"
 
 .PHONY: create-github-release
 create-github-release:


### PR DESCRIPTION
Prepare-release now accepts packages as an array and updates them all.
Also adds a hardcoded list of public repos as packages.