### PR TITLE
chore: add version variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 include build/Makefile.Common
 include build/Makefile.Licenses
+
+govulncheck-version = v1.1.4
+goversioninfo-version = v1.5.0


### PR DESCRIPTION
Add version variables for govulncheck and goversioninfo, as described in PR [#80](https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/80)