### PR TITLE
chore: bumped golang to 1.25.0

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.6
+go 1.25.0
 
 require github.com/google/addlicense v1.1.1
 


### PR DESCRIPTION
chore: bumped golang to 1.25.0