### PR TITLE
chore: bump Go version to 1.25.9

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.8"
+          go-version: "^1.25.9"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.8
+go 1.25.9
 
 require github.com/google/addlicense v1.2.0
 


### PR DESCRIPTION
chore: bump Go version to 1.25.9