### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.11"
+          go-version: "^1.26.4"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.11
+go 1.26.4
 
 require github.com/google/addlicense v1.2.0
 


### PR DESCRIPTION
Update the go.mod toolchain directive(s), the GitHub Actions copilot-setup-steps go-version pin, the CircleCI cimg/go executor image, and the build/docker golang base image where applicable to **1.26.4**.
