### PR TITLE
NH-143198: fix actions/missing-workflow-permissions (1 occurrence)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds an explicit least-privilege top-level `permissions:` block to `.github/workflows/checks.yml` to remediate the CodeQL finding `actions/missing-workflow-permissions`.

Without an explicit block the workflow inherits repository/org default `GITHUB_TOKEN` permissions (potentially read-write). The `checks` job only checks out the repo and runs `make ci-check-licenses`, so `contents: read` is sufficient.

## Change

- `.github/workflows/checks.yml`:15 — add top-level `permissions:` with `contents: read`.

## Coverage

Enumerated all workflows in `.github/workflows/`:
- `checks.yml` — no permissions block → **fixed here**
- `codeql.yml` — already has job-level permissions (not flagged)
- `copilot-setup-steps.yml` — already has job-level permissions (not flagged)
- `dependency-review.yml` — already has top-level permissions (not flagged)

Only `checks.yml` was missing permissions; single occurrence.

## Verification

- YAML validated (`yaml.safe_load` parses; top-level `permissions: {contents: read}`).
- No Go source touched → no build/test impact.

Resolves: [NH-143198](https://swicloud.atlassian.net/browse/NH-143198)


[NH-143198]: https://swicloud.atlassian.net/browse/NH-143198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ