### PR TITLE
NH-143609: bump actions/setup-node to 7

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,7 @@ jobs:
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-node` from `v6` to `v7` in `.github/workflows/copilot-setup-steps.yml` (single usage in this repo).
- Security remediation per Dependabot alert.

## Verification
- Confirmed single usage of `actions/setup-node` in the repo's workflows.
- YAML parses successfully after the edit.

Resolves: [NH-143609](https://swicloud.atlassian.net/browse/NH-143609)

[NH-143609]: https://swicloud.atlassian.net/browse/NH-143609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ