### PR TITLE
NH-143608: bump actions/setup-go to 7

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "^1.26.5"
 


### PR DESCRIPTION
## Summary
- Bumps the `actions/setup-go` GitHub Actions pin from `v6` to `v7` in `.github/workflows/copilot-setup-steps.yml` (line 40) to address a Dependabot-flagged security vulnerability.
- Single usage in the repo; plain version-string edit; no Go toolchain compatibility impact.

Resolves: [NH-143608](https://swicloud.atlassian.net/browse/NH-143608)

## Verification
- YAML parses cleanly.
- Confirmed only one usage of `actions/setup-go` in `.github/workflows/`.
- Workflow-only change; no Go source modified, so no build/test run required locally.

[NH-143608]: https://swicloud.atlassian.net/browse/NH-143608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ