### PR TITLE
chore: move github-actions dependabot updates to thursday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,7 @@ updates:
       - Skip Changelog
     schedule:
       interval: weekly
-      day: saturday
+      day: thursday
     commit-message:
       prefix: "chore: "
 


### PR DESCRIPTION
Move the `github-actions` dependabot ecosystem update day from **saturday** to **thursday**, matching the `gomod` schedule so all dependabot PRs open on the same weekday instead of over the weekend.

- Single-line change in `.github/dependabot.yaml` (`day: saturday` → `day: thursday`).
- No other dependabot settings touched.